### PR TITLE
Update to Postgres 16 img & fix logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,10 +273,13 @@ dynamodb_fdw could be a bit more still, I think.  Here are some areas that it co
 If you want to develop on dynamodb_fdw, you can use the devshell provided by `flake.nix`, and the [nix-direnv](https://github.com/nix-community/nix-direnv) tool.  This will automatically set up a PostgreSQL system with Multicorn2 available, a Python with Multicorn2 available, and configure PYTHONPATH so that the current working directory is included for development purposes.  Once you're up and running in a nix-direnv shell, you'll need to start a PostgreSQL server:
 
 ```
-initdb -D ./tmp
+initdb \
+    -E UTF8 \
+    --set unix_socket_directories="" \
+    --set log_min_messages="debug" \
+    --auth-host=trust \
+    -D ./tmp
 ```
-
-If you're using NixOS, you'll find that PostgreSQL will fail to startup due to the `unix_socket_directories` default setting.  Edit tmp/postgresql.conf and change `unix_socket_directories = ''` to remove the default `/run/postgresql` directory, allowing only TCP connections.  If you're not using NixOS, you can ignore this step.
 
 Then start the PostgreSQL server:
 
@@ -284,7 +287,7 @@ Then start the PostgreSQL server:
 postgres -D ./tmp
 ```
 
-You can then connect to the running PostgreSQL instance and run commands to set-up, use, and test the dynamodb_fdw module.  Here's an example of setting up the module and querying a table:
+You can then connect to the running PostgreSQL instance and run commands to set-up, use, and test the dynamodb_fdw module, or, run the dynamodb_fdw integration tests.  Here's an example of setting up the module and querying a table:
 
 ```
 $ psql -h localhost postgres $(whoami)

--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
       },
       "locked": {
         "dir": "flake",
-        "lastModified": 1715000677,
-        "narHash": "sha256-JmN7WhWiGY431R5zlvkVVifgxwzISjM+3xirR+Ju3pI=",
+        "lastModified": 1715043664,
+        "narHash": "sha256-I7r6EUxbLuaUOiAEJ2MKsURc0Sy/et+vph1BktXjbiQ=",
         "owner": "mfenniak",
         "repo": "custom-nixpkgs",
-        "rev": "8f0ea2e0631509e834117108763348b02d0e024a",
+        "rev": "4fb536a6b0c8b3d48eebe805a68c6bb7ecdf08d4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -111,6 +111,7 @@
             echo "*** Warning: PostgreSQL has been initialized to allow access without a password. ***"
             echo "*** This is insecure and should only be used for development purposes. ***"
             echo ""
+            echo "host all all all trust" >> /data/pg_hba.conf
             # Init multicorn and the multicorn_dynamo server.
             echo "CREATE EXTENSION multicorn; CREATE SERVER multicorn_dynamo FOREIGN DATA WRAPPER multicorn options ( wrapper 'dynamodbfdw.dynamodbfdw.DynamoFdw' )" \
               | ${postgresqlWithDynamodb_fdw}/bin/postgres --single -D /data postgres

--- a/flake.nix
+++ b/flake.nix
@@ -107,13 +107,10 @@
               --set listen_addresses="*" \
               --auth-host=trust \
               -D /data
-            ${pkgs.gnused}/bin/sed -i "s/#unix_socket_directories = '\/run\/postgresql'/unix_socket_directories = '''/" /data/postgresql.conf
-            ${pkgs.gnused}/bin/sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/" /data/postgresql.conf
             echo ""
             echo "*** Warning: PostgreSQL has been initialized to allow access without a password. ***"
             echo "*** This is insecure and should only be used for development purposes. ***"
             echo ""
-            echo "host all all all trust" >> /data/pg_hba.conf
             # Init multicorn and the multicorn_dynamo server.
             echo "CREATE EXTENSION multicorn; CREATE SERVER multicorn_dynamo FOREIGN DATA WRAPPER multicorn options ( wrapper 'dynamodbfdw.dynamodbfdw.DynamoFdw' )" \
               | ${postgresqlWithDynamodb_fdw}/bin/postgres --single -D /data postgres

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
     flake-utils.lib.eachDefaultSystem (system: let
       debugBuild = false;
       pkgs = nixpkgs.legacyPackages.${system};
-      postgresql = pkgs.postgresql.overrideAttrs (oldAttrs: {} // pkgs.lib.optionalAttrs debugBuild { dontStrip = true; }); # If debug symbols are needed.
+      postgresql = pkgs.postgresql_16.overrideAttrs (oldAttrs: {} // pkgs.lib.optionalAttrs debugBuild { dontStrip = true; }); # If debug symbols are needed.
       python = pkgs.python3;
       multicorn2 = (mfenniak.packages.${system}.multicorn2 postgresql python)
         .overrideAttrs (oldAttrs: {} // pkgs.lib.optionalAttrs debugBuild {
@@ -101,7 +101,12 @@
             # Multicorn seems to try to avoid this... https://github.com/pgsql-io/multicorn2/blob/19d9ef571baa21833d75e4d587807bca19de5efe/src/python.c#L104-L114
             # but this function isn't used in PyString_AsString... https://github.com/pgsql-io/multicorn2/blob/19d9ef571baa21833d75e4d587807bca19de5efe/src/python.c#L172
             # Should probably be reported upstream...
-            ${postgresqlWithDynamodb_fdw}/bin/initdb -E UTF8 -D /data
+            ${postgresqlWithDynamodb_fdw}/bin/initdb \
+              -E UTF8 \
+              --set unix_socket_directories="" \
+              --set listen_addresses="*" \
+              --auth-host=trust \
+              -D /data
             ${pkgs.gnused}/bin/sed -i "s/#unix_socket_directories = '\/run\/postgresql'/unix_socket_directories = '''/" /data/postgresql.conf
             ${pkgs.gnused}/bin/sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/" /data/postgresql.conf
             echo ""


### PR DESCRIPTION
Pull up to a prerelease multicorn2 nix package which has fixed logging so that it isn't being sent nowhere.

PG 16 allows "--set" on initdb commands, making it more convenient to initialize and work with.