### PR TITLE
Allow insert & retrieval of binary data via bytes objects

### DIFF
--- a/dynamodbfdw/dynamodbfdw.py
+++ b/dynamodbfdw/dynamodbfdw.py
@@ -14,7 +14,7 @@ def map_python_types_to_dynamodb(value):
     Recursively convert all bytes objects to boto3's Binary wrapper in the given dictionary.
     """
     if isinstance(value, bytes):
-        raise Exception("converting %r to Binary")
+        raise Exception("debug output -- successfully hit bytes type -- converting %r to Binary") # FIXME: Remove
         return Binary(value)
     elif isinstance(value, dict):
         return {k: map_python_types_to_dynamodb(v) for k, v in value.items()}

--- a/dynamodbfdw/test_dynamodbfdw.py
+++ b/dynamodbfdw/test_dynamodbfdw.py
@@ -47,7 +47,7 @@ def test_convert_list_with_bytes():
     assert isinstance(output_data[2]['nested_key'], Binary)
     assert output_data[2]['nested_key'].value == b'nested_bytes_data'
 
-def test_no_conversion_needed():
+def test_map_to_dynamodb_no_conversion_needed():
     # Test with a dictionary containing no bytes objects
     input_data = {
         'key1': 'string_data',
@@ -58,4 +58,56 @@ def test_no_conversion_needed():
         }
     }
     output_data = dynamodbfdw.map_python_types_to_dynamodb(input_data)
+    assert output_data == input_data
+
+def test_convert_binary_to_bytes():
+    # Test with a single Binary object
+    input_data = Binary(b'test_bytes')
+    output_data = dynamodbfdw.map_dynamodb_types_to_python(input_data)
+    assert isinstance(output_data, bytes)
+    assert output_data == b'test_bytes'
+
+def test_convert_nested_dict_with_binary():
+    # Test with a nested dictionary containing Binary objects
+    input_data = {
+        'key1': Binary(b'bytes_data'),
+        'key2': {
+            'nested_key1': Binary(b'nested_bytes_data'),
+            'nested_key2': 'string_data'
+        },
+        'key3': [Binary(b'list_bytes_data'), 'list_string_data']
+    }
+    output_data = dynamodbfdw.map_dynamodb_types_to_python(input_data)
+    
+    assert isinstance(output_data['key1'], bytes)
+    assert output_data['key1'] == b'bytes_data'
+    assert isinstance(output_data['key2']['nested_key1'], bytes)
+    assert output_data['key2']['nested_key1'] == b'nested_bytes_data'
+    assert output_data['key2']['nested_key2'] == 'string_data'
+    assert isinstance(output_data['key3'][0], bytes)
+    assert output_data['key3'][0] == b'list_bytes_data'
+    assert output_data['key3'][1] == 'list_string_data'
+
+def test_convert_list_with_binary():
+    # Test with a list containing Binary objects
+    input_data = [Binary(b'bytes_data'), 'string_data', {'nested_key': Binary(b'nested_bytes_data')}]
+    output_data = dynamodbfdw.map_dynamodb_types_to_python(input_data)
+    
+    assert isinstance(output_data[0], bytes)
+    assert output_data[0] == b'bytes_data'
+    assert output_data[1] == 'string_data'
+    assert isinstance(output_data[2]['nested_key'], bytes)
+    assert output_data[2]['nested_key'] == b'nested_bytes_data'
+
+def test_map_to_python_no_conversion_needed():
+    # Test with a dictionary containing no Binary objects
+    input_data = {
+        'key1': 'string_data',
+        'key2': 123,
+        'key3': {
+            'nested_key1': 'nested_string_data',
+            'nested_key2': [1, 2, 3]
+        }
+    }
+    output_data = dynamodbfdw.map_dynamodb_types_to_python(input_data)
     assert output_data == input_data

--- a/dynamodbfdw/test_dynamodbfdw.py
+++ b/dynamodbfdw/test_dynamodbfdw.py
@@ -1,5 +1,61 @@
 from . import dynamodbfdw
+from boto3.dynamodb.types import Binary
 import json
 
 def test_json_encoder_set():
     json.dumps({ 'a set': set([1, 2, 3]) }, cls=dynamodbfdw.MyJsonEncoder)
+
+def test_json_binary_set():
+    json.dumps({ 'a binary': Binary(b'123') }, cls=dynamodbfdw.MyJsonEncoder)
+
+def test_convert_bytes_to_binary():
+    # Test with a single bytes object
+    input_data = b'test_bytes'
+    output_data = dynamodbfdw.map_python_types_to_dynamodb(input_data)
+    assert isinstance(output_data, Binary)
+    assert output_data.value == input_data
+
+def test_convert_nested_dict_with_bytes():
+    # Test with a nested dictionary containing bytes
+    input_data = {
+        'key1': b'bytes_data',
+        'key2': {
+            'nested_key1': b'nested_bytes_data',
+            'nested_key2': 'string_data'
+        },
+        'key3': [b'list_bytes_data', 'list_string_data']
+    }
+    output_data = dynamodbfdw.map_python_types_to_dynamodb(input_data)
+
+    assert isinstance(output_data['key1'], Binary)
+    assert output_data['key1'].value == b'bytes_data'
+    assert isinstance(output_data['key2']['nested_key1'], Binary)
+    assert output_data['key2']['nested_key1'].value == b'nested_bytes_data'
+    assert output_data['key2']['nested_key2'] == 'string_data'
+    assert isinstance(output_data['key3'][0], Binary)
+    assert output_data['key3'][0].value == b'list_bytes_data'
+    assert output_data['key3'][1] == 'list_string_data'
+
+def test_convert_list_with_bytes():
+    # Test with a list containing bytes
+    input_data = [b'bytes_data', 'string_data', {'nested_key': b'nested_bytes_data'}]
+    output_data = dynamodbfdw.map_python_types_to_dynamodb(input_data)
+
+    assert isinstance(output_data[0], Binary)
+    assert output_data[0].value == b'bytes_data'
+    assert output_data[1] == 'string_data'
+    assert isinstance(output_data[2]['nested_key'], Binary)
+    assert output_data[2]['nested_key'].value == b'nested_bytes_data'
+
+def test_no_conversion_needed():
+    # Test with a dictionary containing no bytes objects
+    input_data = {
+        'key1': 'string_data',
+        'key2': 123,
+        'key3': {
+            'nested_key1': 'nested_string_data',
+            'nested_key2': [1, 2, 3]
+        }
+    }
+    output_data = dynamodbfdw.map_python_types_to_dynamodb(input_data)
+    assert output_data == input_data

--- a/flake.lock
+++ b/flake.lock
@@ -29,11 +29,11 @@
       },
       "locked": {
         "dir": "flake",
-        "lastModified": 1715043664,
-        "narHash": "sha256-I7r6EUxbLuaUOiAEJ2MKsURc0Sy/et+vph1BktXjbiQ=",
+        "lastModified": 1715707328,
+        "narHash": "sha256-fKhpmK7Yzg9AY01mmm3iq+rQ7prPxgETJbtL0j4349c=",
         "owner": "mfenniak",
         "repo": "custom-nixpkgs",
-        "rev": "4fb536a6b0c8b3d48eebe805a68c6bb7ecdf08d4",
+        "rev": "0c78afdd6cc4f0ea2b60f377a3bd261781dffb9d",
         "type": "github"
       },
       "original": {
@@ -45,11 +45,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714906307,
-        "narHash": "sha256-UlRZtrCnhPFSJlDQE7M0eyhgvuuHBTe1eJ9N9AQlJQ0=",
+        "lastModified": 1715534503,
+        "narHash": "sha256-5ZSVkFadZbFP1THataCaSf0JH2cAH3S29hU9rrxTEqk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "25865a40d14b3f9cf19f19b924e2ab4069b09588",
+        "rev": "2057814051972fa1453ddfb0d98badbea9b83c06",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -16,8 +16,12 @@
     flake-utils.lib.eachDefaultSystem (system: let
       debugBuild = false;
       pkgs = nixpkgs.legacyPackages.${system};
+
+      # PG15 & Python 3.10 are latest supported by multicorn2... but we use PG16 because it has better initdb options
+      # for creating the init script.  Need to get upstream support solid with this version.
       postgresql = pkgs.postgresql_16.overrideAttrs (oldAttrs: {} // pkgs.lib.optionalAttrs debugBuild { dontStrip = true; }); # If debug symbols are needed.
-      python = pkgs.python3;
+      python = pkgs.python310;
+
       multicorn2 = (mfenniak.packages.${system}.multicorn2 postgresql python)
         .overrideAttrs (oldAttrs: {} // pkgs.lib.optionalAttrs debugBuild {
           env.NIX_CFLAGS_COMPILE = "-O0 -g";

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
       # PG15 & Python 3.10 are latest supported by multicorn2... but we use PG16 because it has better initdb options
       # for creating the init script.  Need to get upstream support solid with this version.
       postgresql = pkgs.postgresql_16.overrideAttrs (oldAttrs: {} // pkgs.lib.optionalAttrs debugBuild { dontStrip = true; }); # If debug symbols are needed.
-      python = pkgs.python310;
+      python = pkgs.python3;  # should use python3.10, but, results in a slower CI and we don't have a nix cache there... so... this is fine...
 
       multicorn2 = (mfenniak.packages.${system}.multicorn2 postgresql python)
         .overrideAttrs (oldAttrs: {} // pkgs.lib.optionalAttrs debugBuild {

--- a/test-initdb.sh
+++ b/test-initdb.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+initdb -D ./tmp --auth-host=trust --set unix_socket_directories="" --set listen_addresses="*" --set log_min_messages="debug"  -U postgres

--- a/test-postgres.sh
+++ b/test-postgres.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+postgres -D ./tmp

--- a/tests/integration/test_dynamodbfdw.py
+++ b/tests/integration/test_dynamodbfdw.py
@@ -266,5 +266,10 @@ def test_mapped_attr_insert(pg_connection, custom_import_schema, string_table, s
             'pkey-value-1',
             'test custom field with mapped_attr',
             b'\x00\x01\x02\x03',
-            {'pkey': 'pkey-value-1', 'test_attr': 'test custom field with mapped_attr', 'doc-attr-1': 'doc-value-1'}
+            {
+                'pkey': 'pkey-value-1',
+                'test_attr': 'test custom field with mapped_attr',
+                'test_binary_attr': '\\x00010203',
+                'doc-attr-1': 'doc-value-1'
+            }
         )]

--- a/tests/integration/test_dynamodbfdw.py
+++ b/tests/integration/test_dynamodbfdw.py
@@ -247,8 +247,8 @@ def custom_import_schema(pg_connection, multicorn_dynamo, string_table):
 def string_table_custom_schema_data(pg_connection, string_table):
     with pg_connection.cursor() as cur:
         cur.execute(
-            sql.SQL('INSERT INTO dynamodbfdw_manual_test.{} (pkey, test_text_field, test_bytea_field, document) VALUES (%s, %s, %s, %s)').format(sql.Identifier(string_table)),
-            ['pkey-value-1', 'test custom field with mapped_attr', b'\x00\x00\x00\x01', json.dumps({'doc-attr-1': 'doc-value-1'})]
+            sql.SQL("INSERT INTO dynamodbfdw_manual_test.{} (pkey, test_text_field, test_bytea_field, document) VALUES (%s, %s, '\\x00010203'::bytea, %s)").format(sql.Identifier(string_table)),
+            ['pkey-value-1', 'test custom field with mapped_attr', json.dumps({'doc-attr-1': 'doc-value-1'})]
         )
         pg_connection.commit()
     yield
@@ -265,6 +265,6 @@ def test_mapped_attr_insert(pg_connection, custom_import_schema, string_table, s
             '{"pkey": "pkey-value-1"}',
             'pkey-value-1',
             'test custom field with mapped_attr',
-            b'\x00\x00\x00\x01',
+            b'\x00\x01\x02\x03',
             {'pkey': 'pkey-value-1', 'test_attr': 'test custom field with mapped_attr', 'doc-attr-1': 'doc-value-1'}
         )]

--- a/tests/integration/test_dynamodbfdw.py
+++ b/tests/integration/test_dynamodbfdw.py
@@ -224,3 +224,47 @@ def test_explain_pkey_equal(pg_connection, import_schema, string_string_table):
             "Multicorn:           \"ComparisonOperator\": \"EQ\"",
         ]
         assert_contains_rows(query_plan, required_query_plan_rows)
+
+@pytest.fixture
+def custom_import_schema(pg_connection, multicorn_dynamo, string_table):
+    with pg_connection.cursor() as cur:
+        cur.execute("DROP SCHEMA IF EXISTS dynamodbfdw_manual_test CASCADE")
+        cur.execute("CREATE SCHEMA dynamodbfdw_manual_test")
+        cur.execute(f"""
+            CREATE FOREIGN TABLE dynamodbfdw_manual_test."{string_table}" (
+                oid TEXT,
+                pkey TEXT OPTIONS (mapped_attr 'pkey', partition_key 'true'),
+                test_text_field TEXT OPTIONS (mapped_attr 'test_attr'),
+                test_bytea_field TEXT OPTIONS (mapped_attr 'test_binary_attr'),
+                document JSON OPTIONS (ddb_document 'true')
+            ) SERVER multicorn_dynamo OPTIONS (
+                aws_region '{aws_region}',
+                table_name '{string_table}'
+            )
+        """)
+
+@pytest.fixture
+def string_table_custom_schema_data(pg_connection, string_table):
+    with pg_connection.cursor() as cur:
+        cur.execute(
+            sql.SQL('INSERT INTO dynamodbfdw_manual_test.{} (pkey, test_text_field, test_bytea_field, document) VALUES (%s, %s, %s, %s)').format(sql.Identifier(string_table)),
+            ['pkey-value-1', 'test custom field with mapped_attr', b'\x00\x00\x00\x01', json.dumps({'doc-attr-1': 'doc-value-1'})]
+        )
+        pg_connection.commit()
+    yield
+    with pg_connection.cursor() as cur:
+        cur.execute(sql.SQL('DELETE FROM dynamodbfdw_manual_test.{}').format(sql.Identifier(string_table)))
+        pg_connection.commit()
+
+def test_mapped_attr_insert(pg_connection, custom_import_schema, string_table, string_table_custom_schema_data):
+    with pg_connection.cursor() as cur:
+        # Query to ensure that test_text_field was populated in the DDB record
+        cur.execute(sql.SQL('SELECT oid, pkey, test_text_field, test_bytea_field, document FROM dynamodbfdw_manual_test.{}').format(sql.Identifier(string_table)))
+        data = cur.fetchall()
+        assert data == [(
+            '{"pkey": "pkey-value-1"}',
+            'pkey-value-1',
+            'test custom field with mapped_attr',
+            b'\x00\x00\x00\x01',
+            {'pkey': 'pkey-value-1', 'test_attr': 'test custom field with mapped_attr', 'doc-attr-1': 'doc-value-1'}
+        )]

--- a/tests/integration/test_dynamodbfdw.py
+++ b/tests/integration/test_dynamodbfdw.py
@@ -235,7 +235,7 @@ def custom_import_schema(pg_connection, multicorn_dynamo, string_table):
                 oid TEXT,
                 pkey TEXT OPTIONS (mapped_attr 'pkey', partition_key 'true'),
                 test_text_field TEXT OPTIONS (mapped_attr 'test_attr'),
-                test_bytea_field TEXT OPTIONS (mapped_attr 'test_binary_attr'),
+                test_bytea_field BYTEA OPTIONS (mapped_attr 'test_binary_attr'),
                 document JSON OPTIONS (ddb_document 'true')
             ) SERVER multicorn_dynamo OPTIONS (
                 aws_region '{aws_region}',
@@ -247,8 +247,8 @@ def custom_import_schema(pg_connection, multicorn_dynamo, string_table):
 def string_table_custom_schema_data(pg_connection, string_table):
     with pg_connection.cursor() as cur:
         cur.execute(
-            sql.SQL("INSERT INTO dynamodbfdw_manual_test.{} (pkey, test_text_field, test_bytea_field, document) VALUES (%s, %s, '\\x00010203'::bytea, %s)").format(sql.Identifier(string_table)),
-            ['pkey-value-1', 'test custom field with mapped_attr', json.dumps({'doc-attr-1': 'doc-value-1'})]
+            sql.SQL("INSERT INTO dynamodbfdw_manual_test.{} (pkey, test_text_field, test_bytea_field, document) VALUES (%s, %s, %s, %s)").format(sql.Identifier(string_table)),
+            ['pkey-value-1', 'test custom field with mapped_attr', b'\x00\x01\x02\x03', json.dumps({'doc-attr-1': 'doc-value-1'})]
         )
         pg_connection.commit()
     yield


### PR DESCRIPTION
- Allows reading and writing to arbitrary fields that are marked with `mapped_attr` options
- Support `bytea` (PostgreSQL) types in mapped fields, which are mapped into "Binary" fields in DynamoDB items.

Fixes #19.
